### PR TITLE
Add Alembic setup for outreach models

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -63,7 +63,7 @@ version_path_separator = os
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = %(DATABASE_URL)s
+# sqlalchemy.url is configured in alembic/env.py
 
 
 [post_write_hooks]

--- a/alembic/versions/0001_initial_outreach_schema.py
+++ b/alembic/versions/0001_initial_outreach_schema.py
@@ -1,0 +1,76 @@
+"""Initial outreach schema"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "campaigns",
+        sa.Column("campaign_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+    )
+    op.create_table(
+        "organizations",
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("email_domain", sa.String(), nullable=False),
+        sa.Column("external_id", sa.String(), nullable=True),
+        sa.Column("external_source", sa.String(), nullable=True),
+        sa.Column("website_url", sa.String(), nullable=True),
+        sa.Column("linkedin_url", sa.String(), nullable=True),
+        sa.Column("estimated_num_employees", sa.Integer(), nullable=True),
+        sa.Column("website_summary_data", postgresql.JSONB(), nullable=True),
+        sa.Column("website_raw_data", postgresql.JSONB(), nullable=True),
+        sa.Column("country", sa.String(), nullable=True),
+        sa.Column("language", sa.String(), nullable=True),
+        sa.Column("time_zone", sa.String(), nullable=True),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("formatted_organization_name", sa.String(), nullable=True),
+        sa.Column("raw_address", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+    )
+    op.create_table(
+        "leads",
+        sa.Column("lead_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("campaign_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("campaigns.campaign_id"), nullable=False),
+        sa.Column("company_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("organizations.organization_id"), nullable=False),
+        sa.Column("first_name", sa.String(), nullable=True),
+        sa.Column("last_name", sa.String(), nullable=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("external_id", sa.String(), nullable=True),
+        sa.Column("title", sa.String(), nullable=True),
+        sa.Column("headline", sa.String(), nullable=True),
+        sa.Column("linkedin_url", sa.String(), nullable=True),
+        sa.Column("email_verification_status", sa.String(), nullable=True),
+        sa.Column("email_verification_message", sa.String(), nullable=True),
+        sa.Column("email_icebreaker", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("language", sa.String(), nullable=True),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("email_sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("reply_received_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_contacted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+    )
+    op.create_index("ix_leads_email", "leads", ["email"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_leads_email", table_name="leads")
+    op.drop_table("leads")
+    op.drop_table("organizations")
+    op.drop_table("campaigns")


### PR DESCRIPTION
## Summary
- wire up Alembic configuration to pull metadata from outreach models
- use DATABASE_URL from environment and create an engine directly in Alembic env
- comment out sqlalchemy.url in alembic.ini
- add first migration for outreach tables

## Testing
- `pytest -q` *(fails: command not found)*